### PR TITLE
Fix #5 - systemd OSs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ language: ruby
 cache: bundler
 sudo: false
 
-before_install:
-  - rvm @global do gem uninstall bundler --all --executables
-  - gem uninstall bundler --all --executables
-  - gem install bundler --version '~> 1.5.2'
-  - bundle --version
-bundler_args: --without=development
-
-rvm: 2.2.5
-env: VAGRANT_VERSION=v1.9.1
+rvm: 2.4.2
+env: VAGRANT_VERSION=v2.0.1
 matrix:
   include:
-    - env: VAGRANT_VERSION=v1.2.7
-      rvm: 1.9.3
     - env: VAGRANT_VERSION=master
+    - env: VAGRANT_VERSION=v2.0.1
+      rvm: 2.4.2
+    - env: VAGRANT_VERSION=v2.0.1
+      rvm: 2.3.3
+    - env: VAGRANT_VERSION=v2.0.0
+      rvm: 2.2.5
+    - env: VAGRANT_VERSION=v1.9.8
+      rvm: 2.3.3
+    - env: VAGRANT_VERSION=v1.9.8
+      rvm: 2.2.5
   allow_failures:
     - env: VAGRANT_VERSION=master

--- a/lib/vagrant-timezone/action/set_timezone.rb
+++ b/lib/vagrant-timezone/action/set_timezone.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           if timezone.nil?
             logger.info I18n.t('vagrant_timezone.not_enabled')
           elsif machine.guest.capability?(:change_timezone)
-            env[:ui].info I18n.t('vagrant_timezone.configuring')
+            env[:ui].info I18n.t('vagrant_timezone.configuring', zone: timezone)
             machine.guest.capability(:change_timezone, timezone)
           else
             logger.info I18n.t('vagrant_timezone.not_supported')

--- a/lib/vagrant-timezone/cap/debian.rb
+++ b/lib/vagrant-timezone/cap/debian.rb
@@ -6,8 +6,12 @@ module VagrantPlugins
         # Set the time zone
         def self.change_timezone(machine, timezone)
           machine.communicate.tap do |comm|
-            comm.sudo("echo '#{timezone}' > /etc/timezone")
-            comm.sudo('dpkg-reconfigure --frontend noninteractive tzdata')
+            if comm.test('which timedatectl', sudo: true)
+              comm.sudo("timedatectl set-timezone '#{timezone}'")
+            else
+              comm.sudo("echo '#{timezone}' > /etc/timezone")
+              comm.sudo('dpkg-reconfigure --frontend noninteractive tzdata')
+            end
           end
         end
       end

--- a/lib/vagrant-timezone/cap/redhat.rb
+++ b/lib/vagrant-timezone/cap/redhat.rb
@@ -7,10 +7,13 @@ module VagrantPlugins
       class RedHat < Unix
         # Set the time zone
         def self.change_timezone(machine, timezone)
-          super
-
-          machine.communicate.sudo(
-            "echo 'ZONE=\"#{timezone}\"' > /etc/sysconfig/clock")
+          machine.communicate.tap do |comm|
+            if comm.test('which timedatectl', sudo: true)
+              comm.sudo("timedatectl set-timezone '#{timezone}'")
+            else
+              comm.sudo(
+                "echo 'ZONE=\"#{timezone}\"' > /etc/sysconfig/clock")
+            end
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,7 +2,7 @@ en:
   vagrant_timezone:
     not_enabled: "Time zone not configured"
     not_supported: "Setting time zone not supported"
-    configuring: "Setting time zone..."
+    configuring: "Setting time zone to '%{zone}'..."
 
     errors:
       vagrant_version: |-


### PR DESCRIPTION
Fixes #5 on modernish (2014+) Debian/Ubuntu systems to use `timedatectl`
Also prints the timezone during host startup

Tested with Vagrant 2.0.0