### PR TITLE
Fix and update Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,22 @@ language: ruby
 cache: bundler
 sudo: false
 
-before_install:
-  - rvm @global do gem uninstall bundler --all --executables
-  - gem uninstall bundler --all --executables
-  - gem install bundler --version '~> 1.5.2'
-  - bundle --version
+before_install: ./travis/before_install
 bundler_args: --without=development
 
-rvm: 2.2.5
-env: VAGRANT_VERSION=v1.9.1
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+rvm: 2.4.4
 matrix:
   include:
-    - env: VAGRANT_VERSION=v1.2.7
-      rvm: 1.9.3
+    - env: VAGRANT_VERSION=v2.2.2
+    - env: VAGRANT_VERSION=v2.0.4
+    - env:
+        - VAGRANT_VERSION=v1.8.7
+        - BUNDLER_VERSION=1.12.5
+      rvm: 2.2.5
     - env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'vagrant',
-  git: 'https://github.com/mitchellh/vagrant.git',
-  tag: ENV.fetch('VAGRANT_VERSION', 'v1.9.1')
+  git: 'https://github.com/hashicorp/vagrant.git',
+  tag: ENV.fetch('VAGRANT_VERSION', 'v2.2.2')
 
 gem 'rake'
 gem 'rspec', '~> 3.1'

--- a/travis/before_install
+++ b/travis/before_install
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+remove_default_specs() {
+    echo "Removing default gemspec"
+    find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete
+}
+
+install_bundler() {
+    echo "Uninstalling current Bundler versions"
+    rvm @global do gem uninstall bundler --all --executables
+    gem uninstall bundler --all --executables
+    echo "Installing Bundler '$BUNDLER_VERSION'"
+    gem install bundler --version "$BUNDLER_VERSION"
+}
+
+print_bundler_version() {
+    bundler --version
+}
+
+if [ -n "${BUNDLER_VERSION:-}" ]; then
+    remove_default_specs
+    install_bundler
+    print_bundler_version
+fi


### PR DESCRIPTION
Test by default with the latest Vagrant v2.2.2. And then with the latest 2.0.x and 1.8.x. Drop test support for older versions.